### PR TITLE
fix(backend): fix bug in backend to use postgres instead of sqlite db

### DIFF
--- a/backend/datapulse/settings/dev.py
+++ b/backend/datapulse/settings/dev.py
@@ -6,13 +6,6 @@ DEBUG = env.bool("DEBUG", default=True)
 
 ALLOWED_HOSTS = ["*"]
 
-# Use SQLite for local development and testing to avoid native dependencies
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
-}
 
 # Run Celery tasks synchronously in dev/test (no broker needed)
 CELERY_TASK_ALWAYS_EAGER = True


### PR DESCRIPTION
## Description
This PR fixes a bug where running `docker compose up` would unintentionally create and connect to a local SQLite database (`db.sqlite3`) instead of the intended Postgres container.

Previously, [docker-compose.yml](cci:7://file:///c:/Users/Amalitech/Desktop/locked_in/z_final_group_project/data-pulse-team-9--2026-03/docker-compose.yml:0:0-0:0) loaded the [.env](cci:7://file:///c:/Users/Amalitech/Desktop/locked_in/z_final_group_project/data-pulse-team-9--2026-03/.env:0:0-0:0) file at the repository root, which specifies `DJANGO_SETTINGS_MODULE=datapulse.settings.dev`. Because [dev.py](cci:7://file:///c:/Users/Amalitech/Desktop/locked_in/z_final_group_project/data-pulse-team-9--2026-03/backend/datapulse/settings/dev.py:0:0-0:0) contained a hardcoded dictionary that forced the `DATABASES` engine to `sqlite3`, it completely bypassed the Postgres `DATABASE_URL` environment variable.

I removed the hardcoded `DATABASES` dictionary override in [backend/datapulse/settings/dev.py](cci:7://file:///c:/Users/Amalitech/Desktop/locked_in/z_final_group_project/data-pulse-team-9--2026-03/backend/datapulse/settings/dev.py:0:0-0:0). It now correctly inherits the `DATABASE_URL` configuration natively from [base.py](cci:7://file:///c:/Users/Amalitech/Desktop/locked_in/z_final_group_project/data-pulse-team-9--2026-03/backend/datapulse/settings/base.py:0:0-0:0), establishing a proper connection to the Postgres instance. I also updated [.gitignore](cci:7://file:///c:/Users/Amalitech/Desktop/locked_in/z_final_group_project/data-pulse-team-9--2026-03/.gitignore:0:0-0:0) to ignore `.sqlite3` files.

## Type of Change
- [ ] `feat` - New feature
- [x] `fix` - Bug fix
- [ ] `devops` - Infrastructure/CI/CD
- [ ] `test` - Tests only
- [ ] `docs` - Documentation
- [ ] `refactor` - Code cleanup

## Related Issue
Closes #42 

## Testing
- [ ] Tests added/updated
- [x] All tests pass locally
- [x] Tested with Docker Compose
- [x] Manual testing completed

## Checklist
- [x] Branch follows `type/description` format
- [x] PR title follows `type(scope): description` format
- [x] No secrets or [.env](cci:7://file:///c:/Users/Amalitech/Desktop/locked_in/z_final_group_project/data-pulse-team-9--2026-03/.env:0:0-0:0) files committed
- [x] Pre-commit hooks passed
- [ ] Documentation updated (if needed)
- [x] Ready for review
