### PR TITLE
fix(devops): remove rate limiting on health and metrics endpoints

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -27,6 +27,7 @@ class MetricsProxyView(APIView):
     """Prometheus Metrics Endpoint."""
 
     permission_classes = [AllowAny]
+    throttle_classes = []
 
     @extend_schema(
         responses={200: str},
@@ -41,6 +42,7 @@ class HealthCheckView(APIView):
     """Robust Health check endpoint."""
 
     permission_classes = [AllowAny]
+    throttle_classes = []
 
     @extend_schema(
         responses={200: dict, 503: dict},


### PR DESCRIPTION
## Description
Fixed an issue where observability tools were being rate-limited when checking the `/health` and `/metrics` endpoints. 

Disabled the global Django REST Framework object-level throttling (`throttle_classes = []`) specifically for [HealthCheckView](cci:2://file:///c:/Users/Amalitech/Desktop/locked_in/z_final_group_project/data-pulse-team-9--2026-03/backend/core/views.py:40:0-80:86) and [MetricsProxyView](cci:2://file:///c:/Users/Amalitech/Desktop/locked_in/z_final_group_project/data-pulse-team-9--2026-03/backend/core/views.py:25:0-37:80). This prevents Prometheus/Grafana scrapers from hitting the default `100/day` anonymous limit, ensuring continuous and reliable monitoring and health checking.

## Type of Change
- [ ] `feat` - New feature
- [x] `fix` - Bug fix
- [ ] `devops` - Infrastructure/CI/CD
- [ ] `test` - Tests only
- [ ] `docs` - Documentation
- [ ] `refactor` - Code cleanup

## Related Issue
<!-- REQUIRED: Link your task -->
Closes # <!-- Insert your issue number here if you have one -->

## Testing
- [ ] Tests added/updated
- [x] All tests pass locally
- [x] Tested with Docker Compose
- [x] Manual testing completed

## Checklist
- [x] Branch follows `type/description` format
- [x] PR title follows `type(scope): description` format
- [x] No secrets or `.env` files committed
- [x] Pre-commit hooks passed
- [ ] Documentation updated (if needed)
- [x] Ready for review
